### PR TITLE
feat: Use glob match to speedup dotroot clean

### DIFF
--- a/dotutil_cz/util.py
+++ b/dotutil_cz/util.py
@@ -261,6 +261,11 @@ class ChezmoiArgs:
         )
         return Path(p.stdout.strip()) if p.returncode == 0 else None
 
+    def source_dir(self) -> Path:
+        if not (v := os.environ.get("CHEZMOI_SOURCE_DIR")):
+            v = self.data()["sourceDir"]
+        return Path(v)
+
 
 class Restic:
     def __init__(self, bin: str, env=None) -> None:


### PR DESCRIPTION
在之前使用对所有.root目录使用cz source-path进程检查是否是exact目录，速度太慢。

现在使用.root目录组成glob对cz源码目录查找加速，未找到才使用cz进程查找，实测提升超过100%，.root目录越多提升越大

参考：

* [Source state attributes](https://www.chezmoi.io/reference/source-state-attributes/)