### PR TITLE
fix: Not found passhole in restic-dump tmpl

### DIFF
--- a/dotutil_cz/dotroot.py
+++ b/dotutil_cz/dotroot.py
@@ -133,7 +133,9 @@ def check_passhole(cz: ChezmoiArgs):
         log.debug(f"finding passhole template in {paths2str(src_paths)}")
 
         if src_paths:
-            pat = re.compile(r'\{\{.*(passhole(\s+".+"){2}).*\}\}')
+            pat = re.compile(
+                r'\{\{.*(passhole(\s+".+"){2})|(includeTemplate\s+"\s*restic-dump\s*"\s+).*\}\}'
+            )
             paths = set()
             # find all files
             for path in src_paths:


### PR DESCRIPTION
在检查passhole时未发现模板restic-dump使用了passhole命令

```sh
$ cz diff -rv ~/.root/etc/nginx
+ exec /home/navyd/.local/share/chezmoi/.venv/bin/python3 -c 'from dotutil_cz import dotroot; dotroot.pre_run()'
2023-07-11 09:45:55.682 [INFO ] [dotutil_cz.dotroot.check_super_permission]: checking super permission with ['/usr/bin/sudo', 'echo'] for /home/navyd/.root/etc/nginx
2023-07-11 09:45:55.721 [INFO ] [dotutil_cz.dotroot.pre_sync_from_root]: syncing root to /home/navyd/.root if changed
2023-07-11 09:45:56.455 [INFO ] [dotutil_cz.dotroot.pre_sync_from_root]: found changed 0 files
Error opening database
Resolving password failed: exit status 1
chezmoi: template: dot_root/etc/nginx/ssl/asterisk.navyd.xyz/create_ca.pem.tmpl:1:4: executing "dot_root/etc/nginx/ssl/asterisk.navyd.xyz/create_ca.pem.tmpl" at <includeTemplate "restic-dump" .>: error calling includeTemplate: restic-dump:6:5: executing "restic-dump" at <output .restic.path "-r" .restic.repo "dump" "--host" .chezmoi.hostname "latest" $dst "--password-command" "ph --no-password show --field password dotfiles/restic-repo">: error calling output: /home/navyd/.local/bin/restic -r /mnt/share/Backups/restic-repo dump --host rpi4 latest /home/navyd/.root/etc/nginx/ssl/asterisk.navyd.xyz/ca.pem --password-command 'ph --no-password show --field password dotfiles/restic-repo': exit status 1
```

这个pr将包含restic-dump的模板作为passhole处理